### PR TITLE
Set event listeners directly rather than with addEventListener

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Passing `children` as an explicit attribute, when there is no other JSX child no
 <div dataset={{ user: "guest", isLoggedIn: false }} />
 ```
 
-2. Attributes starts with `on` and has a function value will be treated as an event listener and attached to the node with `addEventListener`.
+2. Attributes starts with `on` and has a function value will be treated as an event listener and attached to the node by setting the property directly (e.g. `node.onclick = ...`).
 
 ```jsx
 <div onClick={e => e.preventDefault()} />

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,8 +239,7 @@ function attribute(key: string, value: any, node: HTMLElement | SVGElement) {
 
   if (isFunction(value)) {
     if (key[0] === "o" && key[1] === "n") {
-      const name = key.slice(2).toLowerCase()
-      node.addEventListener(name, value)
+      node[key.toLowerCase()] = value
     }
   } else if (value === true) {
     node.setAttribute(key, "")


### PR DESCRIPTION
Hi @proteriax. Thanks for the great package!

Why not set event listeners directly (e.g. `node.onclick = ...`) rather than using `addEventListener`?

The advantage would be that then the event listeners can be seen and copied over when using a dom diffing solution (one that works with real dom objects, rather than a virtual dom, of course.. for example, [morphdom](https://github.com/patrick-steele-idem/morphdom) or [nanomorph](https://github.com/choojs/nanomorph)). 

Is there any disadvantage to doing it this way? 

I believe that `addEventListener` exists so that multiple event listeners can be added for the same event, without the latter listener overwriting the former listener. But that is of no use here, since we can only define a single listener per event in JSX anyways. (e.g. It isn't possible, or even desireable, to do `<button onClick={doSomething} onClick={doSomethingElse}/>`)