### PR TITLE
Allow for use of Fragment in JSX with h

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -196,7 +196,7 @@ interface AttrWithRef<T> extends Attributes {
   ref?: Ref<T>
 }
 
-type ReactElement = HTMLElement | SVGElement
+type ReactElement = HTMLElement | SVGElement | DocumentFragment
 
 type DOMFactory<P extends DOMAttributes<T>, T extends Element> = (
   props?: (AttrWithRef<T> & P) | null,


### PR DESCRIPTION
Before this change, the following in TypeScript:

```typescript
import { h, Fragment } from 'jsx-dom';

export default <Fragment>
  <h1>A</h1>
  <h2>B</h2>
</Fragment>;
```

Would report the following error:

>JSX element type 'DocumentFragment' is not a constructor function for JSX elements

This is the quickest way I found to fix it, but there may be a better way.