### PR TITLE
Add back Fragment support with h after SVG changes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -196,7 +196,7 @@ interface AttrWithRef<T> extends Attributes {
   ref?: Ref<T>
 }
 
-type ReactElement = HTMLElement | SVGElement
+type ReactElement = HTMLElement | SVGElement | DocumentFragment
 
 type DOMFactory<P extends DOMAttributes<T>, T extends Element> = (
   props?: (AttrWithRef<T> & P) | null,


### PR DESCRIPTION
After the SVG changes in the latest release I started getting errors again when using Fragment. After this fix I can use SVG and fragments together without any issues.

I want to use `h` for two reasons: 1) It's cleaner looking without mentioning React, and 2) It minifies better without much effort.