### PR TITLE
fix: template tags not having content

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,7 @@ export function createElement(tag: any, attr: any, ...children: any[]) {
   }
 
   if (attr.children != null && !children.length) {
-    ;({ children, ...attr } = attr)
+    ; ({ children, ...attr } = attr)
   }
 
   let node: HTMLElement | SVGElement
@@ -152,11 +152,11 @@ function appendChild(child: any[] | string | number | null | Element, node: Node
   if (isArrayLike(child)) {
     appendChildren(child as any, node)
   } else if (isString(child) || isNumber(child)) {
-    node.appendChild(document.createTextNode(child as any))
+    appendChildToNode(document.createTextNode(child as any), node)
   } else if (child === null) {
-    node.appendChild(document.createComment(""))
+    appendChildToNode(document.createComment(""), node)
   } else if (isElement(child)) {
-    node.appendChild(child)
+    appendChildToNode(child, node)
   }
 }
 
@@ -165,6 +165,14 @@ function appendChildren(children: any[], node: Node) {
     appendChild(child, node)
   }
   return node
+}
+
+function appendChildToNode(child: Node, node: Node) {
+  if (node instanceof window.HTMLTemplateElement) {
+    node.content.appendChild(child);
+  } else {
+    node.appendChild(child)
+  }
 }
 
 function normalizeAttribute(s: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,7 @@ export function createElement(tag: any, attr: any, ...children: any[]) {
   }
 
   if (attr.children != null && !children.length) {
-    ; ({ children, ...attr } = attr)
+    ;({ children, ...attr } = attr)
   }
 
   let node: HTMLElement | SVGElement

--- a/test/test-main.tsx
+++ b/test/test-main.tsx
@@ -243,4 +243,19 @@ describe("jsx-dom", () => {
       expect(nodes[1].nodeName === "SPAN" && nodes[1].textContent === "Bonjour")
     })
   })
+
+  describe("templates", () => {
+    it("supports templates", () => {
+      const template = (
+        <template>
+          {[2]}
+          <span>Bonjour</span>
+        </template>
+      ) as HTMLTemplateElement
+
+      const nodes = template.content.childNodes
+      expect(nodes[0].nodeType === Node.TEXT_NODE && nodes[0].textContent === "2")
+      expect(nodes[1].nodeName === "SPAN" && nodes[1].textContent === "Bonjour")
+    })
+  })
 })


### PR DESCRIPTION
Resolves #30

Calls `content.appendChild` instead of `appendChild` in the case when the parent node is an instance of `HTMLTemplateElement`.