### PR TITLE
IE11 compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -168,7 +168,10 @@ function appendChildren(children: any[], node: Node) {
 }
 
 function appendChildToNode(child: Node, node: Node) {
-  if (node instanceof window.HTMLTemplateElement) {
+  if (
+    window.HTMLTemplateElement
+    && node instanceof window.HTMLTemplateElement
+  ) {
     node.content.appendChild(child)
   } else {
     node.appendChild(child)


### PR DESCRIPTION
IE11 gives an error message when adding children to a standard `HTMLElement` on line 171 in `appendChildToNode`:
```
"Invalid operand to 'instanceof': Function expected"
```

This just adds a simple check for the existence of window.HTMLTemplateElement before using instanceof.


