### PR TITLE
Fix solution for #33

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -250,7 +250,7 @@ function attribute(key: string, value: any, node: Element & HTMLOrSVGElement) {
     if (key[0] === "o" && key[1] === "n") {
       const attribute = key.toLowerCase()
       // Issue #33
-      if (node[attribute] == null) {
+      if (node[attribute] === null) {
         node[attribute] = value
       } else {
         node.addEventListener(key, value)


### PR DESCRIPTION
This makes a slight correction to c8c24fc1d82c8c329a645c2bb1ebb3b5e7078d73

@proteriax It looks like you were taking the following approach proposed by @kurtinatlanta :
> What I did locally was to check for 'built-in' events (the on... function **will be null instead of undefined**) and set the property for those events but use addEventListener if the on... function in the node is undefined.
https://github.com/proteriax/jsx-dom/issues/33#issuecomment-697023176

But I think you meant to use `===` instead of `==` since in JS `undefined == null` is true.
With `==`, the `if` condition will be `true` regardless of if the property is `null` or `undefined`.
With `===`, the `if` condition will be `true` only if the property is `null`