### PR TITLE
TypeScript fixes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -200,7 +200,7 @@ interface AttrWithRef<T> extends Attributes {
 
 type ReactElement = HTMLElement | SVGElement
 
-type DOMFactory<P extends DOMAttributes<T>, T extends Element> = (
+type DOMFactory<P extends DOMAttributes<T>, T extends Node> = (
   props?: (AttrWithRef<T> & P) | null,
   ...children: ReactNode[]
 ) => T
@@ -227,12 +227,13 @@ interface SVGFactory extends DOMFactory<SVGAttributes<SVGElement>, SVGElement> {
 // ----------------------------------------------------------------------
 
 type ReactText = string | number
-type ReactChild = Element | ReactText
+type ReactChild = Node | ReactText
+type ReactChildren = ReactNodeArray | NodeList | HTMLCollection
 
 interface ReactNodeArray extends Array<ReactNode> {}
 type ReactNode =
   | ReactChild
-  | ReactNodeArray
+  | ReactChildren
   | DocumentFragment
   | Text
   | Comment
@@ -247,7 +248,7 @@ type ReactNode =
 // DOM Elements
 export function createFactory<K extends keyof ReactHTML>(type: K): HTMLFactory<ReactHTML[K]>
 export function createFactory(type: keyof ReactSVG): SVGFactory
-export function createFactory<T extends Element>(type: string): T
+export function createFactory<T extends Node>(type: string): T
 
 // DOM Elements
 export function createElement<K extends keyof ReactHTML, T extends HTMLElementTagNameMap[K]>(
@@ -260,20 +261,20 @@ export function createElement<K extends keyof ReactSVG, T extends ReactSVG[K]>(
   props?: (SVGAttributes<T> & AttrWithRef<T>) | null,
   ...children: ReactNode[]
 ): SVGElement
-export function createElement<T extends Element>(
+export function createElement<T extends Node>(
   type: string,
   props?: (AttrWithRef<T> & DOMAttributes<T>) | null,
   ...children: ReactNode[]
 ): T
 
 // Custom components
-export function createElement<P extends {}, T extends Element>(
+export function createElement<P extends {}, T extends Node>(
   type: ComponentType<P, T>,
   props?: (Attributes & P) | null,
   ...children: ReactNode[]
 ): T
 
-export function createElement<T extends Element>(
+export function createElement<T extends Node>(
   type: string,
   props?: Attributes | null,
   ...children: ReactNode[]
@@ -283,19 +284,19 @@ export function createElement<T extends Element>(
 
 export function Fragment(props: { children?: ReactNode }): any // DocumentFragment
 
-interface FunctionComponent<P = {}, T extends Element = Element> {
+interface FunctionComponent<P = {}, T extends Node = Node> {
   (props: PropsWithChildren<P>, context?: any): T | null
   defaultProps?: Partial<P>
   displayName?: string
 }
 
-export interface ComponentClass<P = {}, T extends Element = Element> {
+export interface ComponentClass<P = {}, T extends Node = Node> {
   new (props: P, context?: any): Component<P, T>
   defaultProps?: Partial<P>
   displayName?: string
 }
 
-export class Component<P = {}, T extends Element = Element> {
+export class Component<P = {}, T extends Node = Node> {
   constructor(props: PropsWithChildren<P>)
   readonly props: PropsWithChildren<P>
   render(): T | null
@@ -303,7 +304,7 @@ export class Component<P = {}, T extends Element = Element> {
 
 type PropsWithChildren<P> = P & { children?: ReactNode }
 
-type ComponentType<P = {}, T extends Element = Element> =
+type ComponentType<P = {}, T extends Node = Node> =
   | ComponentClass<P, T>
   | FunctionComponent<P, T>
 
@@ -412,22 +413,22 @@ type ChangeEvent = Event
 
 type EventHandler<E extends Event, T> = (this: T, event: E & CurrentTarget<T>) => void
 
-type ReactEventHandler<T = Element> = EventHandler<Event, T>
+type ReactEventHandler<T = Node> = EventHandler<Event, T>
 
-type ClipboardEventHandler<T = Element> = EventHandler<ClipboardEvent, T>
-type CompositionEventHandler<T = Element> = EventHandler<CompositionEvent, T>
-type DragEventHandler<T = Element> = EventHandler<DragEvent, T>
-type FocusEventHandler<T = Element> = EventHandler<FocusEvent, T>
-type FormEventHandler<T = Element> = EventHandler<FormEvent, T>
-type ChangeEventHandler<T = Element> = EventHandler<ChangeEvent, T>
-type KeyboardEventHandler<T = Element> = EventHandler<KeyboardEvent, T>
-type MouseEventHandler<T = Element> = EventHandler<MouseEvent, T>
-type TouchEventHandler<T = Element> = EventHandler<TouchEvent, T>
-type PointerEventHandler<T = Element> = EventHandler<PointerEvent, T>
-type UIEventHandler<T = Element> = EventHandler<UIEvent, T>
-type WheelEventHandler<T = Element> = EventHandler<WheelEvent, T>
-type AnimationEventHandler<T = Element> = EventHandler<AnimationEvent, T>
-type TransitionEventHandler<T = Element> = EventHandler<TransitionEvent, T>
+type ClipboardEventHandler<T = Node> = EventHandler<ClipboardEvent, T>
+type CompositionEventHandler<T = Node> = EventHandler<CompositionEvent, T>
+type DragEventHandler<T = Node> = EventHandler<DragEvent, T>
+type FocusEventHandler<T = Node> = EventHandler<FocusEvent, T>
+type FormEventHandler<T = Node> = EventHandler<FormEvent, T>
+type ChangeEventHandler<T = Node> = EventHandler<ChangeEvent, T>
+type KeyboardEventHandler<T = Node> = EventHandler<KeyboardEvent, T>
+type MouseEventHandler<T = Node> = EventHandler<MouseEvent, T>
+type TouchEventHandler<T = Node> = EventHandler<TouchEvent, T>
+type PointerEventHandler<T = Node> = EventHandler<PointerEvent, T>
+type UIEventHandler<T = Node> = EventHandler<UIEvent, T>
+type WheelEventHandler<T = Node> = EventHandler<WheelEvent, T>
+type AnimationEventHandler<T = Node> = EventHandler<AnimationEvent, T>
+type TransitionEventHandler<T = Node> = EventHandler<TransitionEvent, T>
 
 export type DetailedHTMLProps<E extends HTMLAttributes<T>, T> = AttrWithRef<T> & E
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -200,7 +200,7 @@ interface AttrWithRef<T> extends Attributes {
 
 type ReactElement = HTMLElement | SVGElement
 
-type DOMFactory<P extends DOMAttributes<T>, T extends Node> = (
+type DOMFactory<P extends DOMAttributes<T>, T extends Element> = (
   props?: (AttrWithRef<T> & P) | null,
   ...children: ReactNode[]
 ) => T
@@ -248,7 +248,7 @@ type ReactNode =
 // DOM Elements
 export function createFactory<K extends keyof ReactHTML>(type: K): HTMLFactory<ReactHTML[K]>
 export function createFactory(type: keyof ReactSVG): SVGFactory
-export function createFactory<T extends Node>(type: string): T
+export function createFactory<T extends Element>(type: string): T
 
 // DOM Elements
 export function createElement<K extends keyof ReactHTML, T extends HTMLElementTagNameMap[K]>(
@@ -261,20 +261,20 @@ export function createElement<K extends keyof ReactSVG, T extends ReactSVG[K]>(
   props?: (SVGAttributes<T> & AttrWithRef<T>) | null,
   ...children: ReactNode[]
 ): SVGElement
-export function createElement<T extends Node>(
+export function createElement<T extends Element>(
   type: string,
   props?: (AttrWithRef<T> & DOMAttributes<T>) | null,
   ...children: ReactNode[]
 ): T
 
 // Custom components
-export function createElement<P extends {}, T extends Node>(
+export function createElement<P extends {}, T extends Element>(
   type: ComponentType<P, T>,
   props?: (Attributes & P) | null,
   ...children: ReactNode[]
 ): T
 
-export function createElement<T extends Node>(
+export function createElement<T extends Element>(
   type: string,
   props?: Attributes | null,
   ...children: ReactNode[]
@@ -284,7 +284,7 @@ export function createElement<T extends Node>(
 
 export function Fragment(props: { children?: ReactNode }): any // DocumentFragment
 
-export interface FunctionComponent<P = {}, T extends Node = Node> {
+export interface FunctionComponent<P = {}, T extends Element = Element> {
   (props: PropsWithChildren<P>, context?: any): T | null
   defaultProps?: Partial<P>
   displayName?: string
@@ -292,13 +292,13 @@ export interface FunctionComponent<P = {}, T extends Node = Node> {
 
 export { FunctionComponent as FC }
 
-export interface ComponentClass<P = {}, T extends Node = Node> {
+export interface ComponentClass<P = {}, T extends Element = Element> {
   new (props: P, context?: any): Component<P, T>
   defaultProps?: Partial<P>
   displayName?: string
 }
 
-export class Component<P = {}, T extends Node = Node> {
+export class Component<P = {}, T extends Element = Element> {
   constructor(props: PropsWithChildren<P>)
   readonly props: PropsWithChildren<P>
   render(): T | null
@@ -306,7 +306,7 @@ export class Component<P = {}, T extends Node = Node> {
 
 type PropsWithChildren<P> = P & { children?: ReactNode }
 
-type ComponentType<P = {}, T extends Node = Node> =
+type ComponentType<P = {}, T extends Element = Element> =
   | ComponentClass<P, T>
   | FunctionComponent<P, T>
 
@@ -415,22 +415,22 @@ type ChangeEvent = Event
 
 type EventHandler<E extends Event, T> = (this: T, event: E & CurrentTarget<T>) => void
 
-type ReactEventHandler<T = Node> = EventHandler<Event, T>
+type ReactEventHandler<T = Element> = EventHandler<Event, T>
 
-type ClipboardEventHandler<T = Node> = EventHandler<ClipboardEvent, T>
-type CompositionEventHandler<T = Node> = EventHandler<CompositionEvent, T>
-type DragEventHandler<T = Node> = EventHandler<DragEvent, T>
-type FocusEventHandler<T = Node> = EventHandler<FocusEvent, T>
-type FormEventHandler<T = Node> = EventHandler<FormEvent, T>
-type ChangeEventHandler<T = Node> = EventHandler<ChangeEvent, T>
-type KeyboardEventHandler<T = Node> = EventHandler<KeyboardEvent, T>
-type MouseEventHandler<T = Node> = EventHandler<MouseEvent, T>
-type TouchEventHandler<T = Node> = EventHandler<TouchEvent, T>
-type PointerEventHandler<T = Node> = EventHandler<PointerEvent, T>
-type UIEventHandler<T = Node> = EventHandler<UIEvent, T>
-type WheelEventHandler<T = Node> = EventHandler<WheelEvent, T>
-type AnimationEventHandler<T = Node> = EventHandler<AnimationEvent, T>
-type TransitionEventHandler<T = Node> = EventHandler<TransitionEvent, T>
+type ClipboardEventHandler<T = Element> = EventHandler<ClipboardEvent, T>
+type CompositionEventHandler<T = Element> = EventHandler<CompositionEvent, T>
+type DragEventHandler<T = Element> = EventHandler<DragEvent, T>
+type FocusEventHandler<T = Element> = EventHandler<FocusEvent, T>
+type FormEventHandler<T = Element> = EventHandler<FormEvent, T>
+type ChangeEventHandler<T = Element> = EventHandler<ChangeEvent, T>
+type KeyboardEventHandler<T = Element> = EventHandler<KeyboardEvent, T>
+type MouseEventHandler<T = Element> = EventHandler<MouseEvent, T>
+type TouchEventHandler<T = Element> = EventHandler<TouchEvent, T>
+type PointerEventHandler<T = Element> = EventHandler<PointerEvent, T>
+type UIEventHandler<T = Element> = EventHandler<UIEvent, T>
+type WheelEventHandler<T = Element> = EventHandler<WheelEvent, T>
+type AnimationEventHandler<T = Element> = EventHandler<AnimationEvent, T>
+type TransitionEventHandler<T = Element> = EventHandler<TransitionEvent, T>
 
 export type DetailedHTMLProps<E extends HTMLAttributes<T>, T> = AttrWithRef<T> & E
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1105,7 +1105,7 @@ interface DataHTMLAttributes<T> extends HTMLAttributes<T> {
 
 interface DetailsHTMLAttributes<T> extends HTMLAttributes<T> {
   open?: boolean
-  onToggle: ReactEventHandler<T>
+  onToggle?: ReactEventHandler<T>
 }
 
 interface DelHTMLAttributes<T> extends HTMLAttributes<T> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -284,7 +284,7 @@ export function createElement<T extends Node>(
 
 export function Fragment(props: { children?: ReactNode }): any // DocumentFragment
 
-export interface FunctionComponent<P = {}, T extends Node = Node>  {
+export interface FunctionComponent<P = {}, T extends Node = Node> {
   (props: PropsWithChildren<P>, context?: any): T | null
   defaultProps?: Partial<P>
   displayName?: string
@@ -292,7 +292,7 @@ export interface FunctionComponent<P = {}, T extends Node = Node>  {
 
 export { FunctionComponent as FC }
 
-export interface ComponentClass<P = {}, T extends Element = Element> {
+export interface ComponentClass<P = {}, T extends Node = Node> {
   new (props: P, context?: any): Component<P, T>
   defaultProps?: Partial<P>
   displayName?: string

--- a/src/jsx-dom.ts
+++ b/src/jsx-dom.ts
@@ -184,7 +184,7 @@ function appendChild(child: any[] | string | number | null | Element, node: Node
 }
 
 function appendChildren(children: any[], node: Node) {
-  for (const child of children) {
+  for (const child of [...children]) {
     appendChild(child, node)
   }
   return node

--- a/test/test-main.tsx
+++ b/test/test-main.tsx
@@ -139,6 +139,18 @@ describe("jsx-dom", () => {
       expect(node.firstElementChild).to.equal(img)
     })
 
+    it("children must be copied before iteration", () => {
+      const span = document.createElement("span")
+      const img = document.createElement("img")
+      const code = document.createElement("code")
+      span.append(img, code)
+
+      const node = <div>{span.children}</div>
+      expect(node.children).to.have.lengthOf(2)
+      expect(node.firstElementChild).to.equal(img)
+      expect(node.lastElementChild).to.equal(code)
+    })
+
     it("supports passing `children` explicitly", () => {
       expect((<div children="internal" />).textContent).to.equal("internal")
       expect((<div children={["internal", 20]} />).textContent).to.equal("internal20")

--- a/test/test-main.tsx
+++ b/test/test-main.tsx
@@ -60,7 +60,7 @@ describe("jsx-dom", () => {
 
   it("supports dynamic tagname", () => {
     const TagName = "div"
-    expect((<TagName/>).tagName).to.equal(TagName.toUpperCase())
+    expect((<TagName />).tagName).to.equal(TagName.toUpperCase())
   })
 
   it("supports React automatic runtime", () => {

--- a/test/test-main.tsx
+++ b/test/test-main.tsx
@@ -58,6 +58,11 @@ describe("jsx-dom", () => {
     expect((<Component a={1} b={2} c={3} />).innerHTML).to.equal("6")
   })
 
+  it("supports dynamic tagname", () => {
+    const TagName = "div"
+    expect((<TagName/>).tagName).to.equal(TagName.toUpperCase())
+  })
+
   it("supports React automatic runtime", () => {
     expect(
       lib.jsx("div", {
@@ -102,6 +107,36 @@ describe("jsx-dom", () => {
 
     it("supports string as childNode", () => {
       expect((<div>{"text"}</div>).textContent).to.equal("text")
+    })
+
+    it("supports Node as childNode", () => {
+      const span = document.createElement("span")
+      const img = document.createElement("img")
+      span.append(img)
+
+      const node = <div>{span.firstChild}</div>
+      expect(node.children).to.have.lengthOf(1)
+      expect(node.firstElementChild).to.equal(img)
+    })
+
+    it("supports NodeList as childNode", () => {
+      const span = document.createElement("span")
+      const img = document.createElement("img")
+      span.append(img)
+
+      const node = <div>{span.childNodes}</div>
+      expect(node.children).to.have.lengthOf(1)
+      expect(node.firstElementChild).to.equal(img)
+    })
+
+    it("supports HTMLCollection as childNode", () => {
+      const span = document.createElement("span")
+      const img = document.createElement("img")
+      span.append(img)
+
+      const node = <div>{span.children}</div>
+      expect(node.children).to.have.lengthOf(1)
+      expect(node.firstElementChild).to.equal(img)
     })
 
     it("supports passing `children` explicitly", () => {


### PR DESCRIPTION
Fixed some TypeScript-related issues:

1) `DetailsHTMLAttributes<T>.onToggle` was not optional
2) `Node`, `NodeList` and `HTMLCollection` weren't recognized as valid children, but they are
3) This issue is not *really* TypeScript-related, but I found it while testing this PR: array-like `children` object must be copied before iteration, since it may lead us into collection mutation, so this test would fail:

```jsx
it("children must be copied before iteration", () => {
  const span = document.createElement("span")
  const img = document.createElement("img")
  const code = document.createElement("code")
  span.append(img, code)

  const node = <div>{span.children}</div>
  expect(node.children).to.have.lengthOf(2)
  expect(node.firstElementChild).to.equal(img)
  expect(node.lastElementChild).to.equal(code)
})
```