### PR TITLE
Export type FunctionComponent and FC

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -283,11 +283,13 @@ export function createElement<T extends Element>(
 
 export function Fragment(props: { children?: ReactNode }): any // DocumentFragment
 
-interface FunctionComponent<P = {}, T extends Element = Element> {
+export interface FunctionComponent<P = {}, T extends Element = Element> {
   (props: PropsWithChildren<P>, context?: any): T | null
   defaultProps?: Partial<P>
   displayName?: string
 }
+
+export { FunctionComponent as FC }
 
 export interface ComponentClass<P = {}, T extends Element = Element> {
   new (props: P, context?: any): Component<P, T>


### PR DESCRIPTION
Export `FunctionComponent` as well as an alias `FC` in `index.d.ts`. By using `FC`, I don't need to explicitly specify the type of `children`, which can make the code a litter bit cleaner.

A simple example:

```ts
export interface ButtonProps {
  width: number;
  height: number;
}

export const Button: FC<ButtonProps> = ({ width, height, children }) => {
  return <button>{children}</button>;
};
```

BTW, awesome project! 
