### PR TITLE
Added proper support for svg presentation attributes

### DIFF
--- a/src/jsx-dom.ts
+++ b/src/jsx-dom.ts
@@ -99,6 +99,8 @@ const svg = {
   view: 0,
 }
 
+const nonPresentationSVGAttributes = /^(a(ll|t|u)|base[FP]|c(al|lipPathU|on)|di|ed|ex|filter[RU]|g(lyphR|r)|ke|l(en|im)|ma(rker[HUW]|s)|n|pat|pr|point[^e]|re[^n]|s[puy]|st[^or]|ta|textL|vi|xC|y|z)/
+
 export function createFactory(tag: string) {
   return createElement.bind(null, tag)
 }
@@ -198,8 +200,8 @@ function appendChildToNode(child: Node, node: Node) {
   }
 }
 
-function normalizeAttribute(s: string) {
-  return s.replace(/[A-Z\d]/g, (match) => ":" + match.toLowerCase())
+function normalizeAttribute(s: string, separator: string) {
+  return s.replace(/[A-Z\d]/g, (match) => separator + match.toLowerCase())
 }
 
 function attribute(key: string, value: any, node: Element & HTMLOrSVGElement) {
@@ -212,15 +214,15 @@ function attribute(key: string, value: any, node: Element & HTMLOrSVGElement) {
       case "xlinkShow":
       case "xlinkTitle":
       case "xlinkType":
-        attrNS(node, XLinkNamespace, normalizeAttribute(key), value)
+        attrNS(node, XLinkNamespace, normalizeAttribute(key, ":"), value)
         return
       case "xmlnsXlink":
-        attr(node, normalizeAttribute(key), value)
+        attr(node, normalizeAttribute(key, ":"), value)
         return
       case "xmlBase":
       case "xmlLang":
       case "xmlSpace":
-        attrNS(node, XMLNamespace, normalizeAttribute(key), value)
+        attrNS(node, XMLNamespace, normalizeAttribute(key, ":"), value)
         return
     }
   }
@@ -282,7 +284,11 @@ function attribute(key: string, value: any, node: Element & HTMLOrSVGElement) {
   } else if (value === true) {
     attr(node, key, "")
   } else if (value !== false && value != null) {
-    attr(node, key, value)
+    if (__FULL_BUILD__ && node instanceof SVGElement && !nonPresentationSVGAttributes.test(key)) {
+      attr(node, normalizeAttribute(key, "-"), value)
+    } else {
+      attr(node, key, value)
+    }
   }
 }
 

--- a/test/register.js
+++ b/test/register.js
@@ -12,6 +12,7 @@ Object.assign(global, {
   Node: window.Node,
   Text: window.Text,
   HTMLElement: window.HTMLElement,
+  SVGElement: window.SVGElement,
   HTMLButtonElement: window.HTMLButtonElement,
   DOMTokenList: window.DOMTokenList,
   customElements: window.customElements,

--- a/test/test-svg.tsx
+++ b/test/test-svg.tsx
@@ -111,4 +111,166 @@ describe("SVG", () => {
       "strokeWidth",
     ].forEach((key) => test(key))
   })
+
+  it("supports presentation svg attributes", () => {
+    const element = (
+      <svg>
+        <path
+          accentHeight="auto"
+          alignmentBaseline="auto"
+          arabicForm="initial"
+          baselineShift="auto"
+          capHeight="auto"
+          clipPath="auto"
+          clipRule="auto"
+          colorInterpolation="auto"
+          colorInterpolationFilters="auto"
+          colorProfile="auto"
+          colorRendering="auto"
+          dominantBaseline="auto"
+          enableBackground="auto"
+          fillOpacity="auto"
+          fillRule="inherit"
+          floodColor="auto"
+          floodOpacity="auto"
+          fontFamily="auto"
+          fontSize="auto"
+          fontSizeAdjust="auto"
+          fontStretch="auto"
+          fontStyle="auto"
+          fontVariant="auto"
+          fontWeight="auto"
+          glyphName="auto"
+          glyphOrientationHorizontal="auto"
+          glyphOrientationVertical="auto"
+          horizAdvX="auto"
+          horizOriginX="auto"
+          imageRendering="auto"
+          letterSpacing="auto"
+          lightingColor="auto"
+          markerEnd="auto"
+          markerMid="auto"
+          markerStart="auto"
+          overlinePosition="auto"
+          overlineThickness="auto"
+          panose1="auto"
+          paintOrder="auto"
+          pointerEvents="auto"
+          renderingIntent="auto"
+          shapeRendering="auto"
+          stopColor="auto"
+          stopOpacity="auto"
+          strikethroughPosition="auto"
+          strikethroughThickness="auto"
+          strokeDasharray="auto"
+          strokeDashoffset="auto"
+          strokeLinecap="inherit"
+          strokeLinejoin="inherit"
+          strokeMiterlimit="auto"
+          strokeOpacity="auto"
+          strokeWidth="auto"
+          textAnchor="auto"
+          textDecoration="auto"
+          textRendering="auto"
+          underlinePosition="auto"
+          underlineThickness="auto"
+          unicodeBidi="auto"
+          unicodeRange="auto"
+          unitsPerEm="auto"
+          vAlphabetic="auto"
+          vHanging="auto"
+          vIdeographic="auto"
+          vMathematical="auto"
+          vectorEffect="auto"
+          vertAdvY="auto"
+          vertOriginX="auto"
+          vertOriginY="auto"
+          wordSpacing="auto"
+          writingMode="auto"
+          xHeight="auto"
+        />
+      </svg>
+    );
+
+    [...element.firstElementChild.attributes as any as Array<Attr>]
+    .map(x => x.name)
+    .forEach(x => expect(x).to.include("-"))
+  })
+
+  it("supports non-presentation svg attributes", () => {
+    const element = (
+      <svg>
+        <path
+          allowReorder="yes"
+          attributeName="auto"
+          attributeType="auto"
+          autoReverse={true}
+          baseFrequency="auto"
+          baseProfile="auto"
+          calcMode="auto"
+          clipPathUnits="auto"
+          contentScriptType="auto"
+          contentStyleType="auto"
+          diffuseConstant="auto"
+          edgeMode="auto"
+          externalResourcesRequired={true}
+          filterRes="auto"
+          filterUnits="auto"
+          glyphRef="auto"
+          gradientTransform="auto"
+          gradientUnits="auto"
+          kernelMatrix="auto"
+          kernelUnitLength="auto"
+          keyPoints="auto"
+          keySplines="auto"
+          keyTimes="auto"
+          lengthAdjust="auto"
+          limitingConeAngle="auto"
+          markerHeight="auto"
+          markerUnits="auto"
+          markerWidth="auto"
+          maskContentUnits="auto"
+          maskUnits="auto"
+          numOctaves="auto"
+          pathLength="auto"
+          patternContentUnits="auto"
+          patternTransform="auto"
+          patternUnits="auto"
+          pointsAtX="auto"
+          pointsAtY="auto"
+          pointsAtZ="auto"
+          preserveAlpha={true}
+          preserveAspectRatio="auto"
+          primitiveUnits="auto"
+          refX="auto"
+          refY="auto"
+          repeatCount="auto"
+          repeatDur="auto"
+          requiredExtensions="auto"
+          requiredFeatures="auto"
+          specularConstant="auto"
+          specularExponent="auto"
+          spreadMethod="auto"
+          startOffset="auto"
+          stdDeviation="auto"
+          stitchTiles="auto"
+          surfaceScale="auto"
+          systemLanguage="auto"
+          tableValues="auto"
+          targetX="auto"
+          targetY="auto"
+          textLength="auto"
+          viewBox="auto"
+          viewTarget="auto"
+          xChannelSelector="auto"
+          yChannelSelector="auto"
+          zoomAndPan="auto"
+        />
+      </svg>
+    );
+
+    [...element.firstElementChild.attributes as any as Array<Attr>]
+    .map(x => x.name)
+    .forEach(x => expect(x).to.not.include("-"))
+  })
 })

--- a/test/test-svg.tsx
+++ b/test/test-svg.tsx
@@ -194,7 +194,7 @@ describe("SVG", () => {
 
     [...element.firstElementChild.attributes as any as Array<Attr>]
     .map(x => x.name)
-    .forEach(x => expect(x).to.include("-"))
+    .forEach(x => expect(/^[^A-Z]*$/.test(x)).to.be.true)
   })
 
   it("supports non-presentation svg attributes", () => {


### PR DESCRIPTION
## Description

`jsx-dom` doesn't currently support SVG presentation attributes, so this code, for example:

```jsx
<svg class="octicon octicon-book" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true">
    <path fillRule="evenodd" d="M0 1.75A.75.75 0 01.75 1h4.253c1.227 0 2.317.59 3 1.501A3.744 3.744 0 0111.006 1h4.245a.75.75 0 01.75.75v10.5a.75.75 0 01-.75.75h-4.507a2.25 2.25 0 00-1.591.659l-.622.621a.75.75 0 01-1.06 0l-.622-.621A2.25 2.25 0 005.258 13H.75a.75.75 0 01-.75-.75V1.75zm8.755 3a2.25 2.25 0 012.25-2.25H14.5v9h-3.757c-.71 0-1.4.201-1.992.572l.004-7.322zm-1.504 7.324l.004-5.073-.002-2.253A2.25 2.25 0 005.003 2.5H1.5v9h3.757a3.75 3.75 0 011.994.574z"/>
</svg>
```
won't generate expected output (`fillRule` remains camelCase instead of being hyphenated - `fill-rule`). This PR solves the issue.

## Why do we need camelCase for these properties at all?

1) Type checking
2) Sometimes we just can't change the source code of a component. E.g., there're plugins that convert svg files to React components. Thus, we can use svg both as a regular picture and as a full-fledged component. They all convert svg presentation properties to camelCase, since React handles them that way. As a result, when we try to use such a plugin together with jsx-dom, we will simply get an invalid svg as the output. Life story: yesterday I was forced to change some properties of my webpack config from this:

```js
{
  loader: "react-svg-loader",
  options: {
    jsx: true
  }
}
```

to this:

```js
// Best practices in the industry right over here!
// Pls star my repo
{
  loader: "append-prepend-loader",
  options: {
    prepend: "export default () => (",
    append: ")",
  },
},
```

:D

## Implementation details

As I can say by past complaints in various issues, people are already confused by the size of a full build, which includes all the SVG goodies. So I tried to implement support for presentation attributes in the shortest possible way and without actually listing them. The result of this attempt is a regular expression that performs all the necessary "magic".

I don't know exactly which is more important at the moment: a cleaner but longer solution, or a shorter one but that can be considered "hacky". If you're ok with another one huge object like `svg`, I can replace the regex with the proper list of attributes.