### PR TITLE
Fixed Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,9 @@ before_install:
   - curl -L https://pnpm.js.org/pnpm.js | node - add --global pnpm
   - pnpm config set store-dir ~/.pnpm-store
 install:
-  - pnpm install --dev --prod --ignore-scripts
+  - pnpm install --ignore-scripts
 before_script:
   - pnpm lint
 script:
   - pnpm build
   - pnpm test
-env:
-  - NODE_ENV=development
-  - NODE_ENV=production

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,15 @@ cache:
   directories:
     - "~/.pnpm-store"
 before_install:
-  - curl -L https://unpkg.com/@pnpm/self-installer | node
+  - curl -L https://pnpm.js.org/pnpm.js | node - add --global pnpm
   - pnpm config set store-dir ~/.pnpm-store
 install:
-  - pnpm install -D
+  - pnpm install --dev --ignore-scripts
+  - pnpm install --prod --ignore-scripts
 before_script:
   - pnpm lint
 script:
+  - pnpm build
   - pnpm test
 env:
   - NODE_ENV=development

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ before_install:
   - curl -L https://pnpm.js.org/pnpm.js | node - add --global pnpm
   - pnpm config set store-dir ~/.pnpm-store
 install:
-  - pnpm install --dev --ignore-scripts
-  - pnpm install --prod --ignore-scripts
+  - pnpm install --dev --prod --ignore-scripts
 before_script:
   - pnpm lint
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ before_install:
   - curl -L https://unpkg.com/@pnpm/self-installer | node
   - pnpm config set store-dir ~/.pnpm-store
 install:
-  - pnpm install
+  - pnpm install --dev
+  - pnpm install --prod
 before_script:
   - pnpm lint
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ before_install:
   - curl -L https://unpkg.com/@pnpm/self-installer | node
   - pnpm config set store-dir ~/.pnpm-store
 install:
-  - pnpm install --dev
-  - pnpm install --prod
+  - pnpm install -D
 before_script:
   - pnpm lint
 script:

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r ts-node/register/transpile-only
+#!/usr/bin/env ts-node-transpile-only
 import * as fs from "fs-extra"
 import { resolve } from "path"
 import babel from "@rollup/plugin-babel"


### PR DESCRIPTION
## Description

## Linux and multiple arguments in shebang

Long story short:

![1](https://user-images.githubusercontent.com/40232067/110111133-87290900-7db8-11eb-8067-3f679bba0834.png)

![2](https://user-images.githubusercontent.com/40232067/110111137-88f2cc80-7db8-11eb-8920-410bc98cfa2d.png)

## pnpm and NODE_ENV

First of all, current `pnpm` installation method is outdated and technically no longer supported.

Secondly, the process of building a script doesn't depend on the environment, but presented `NODE_ENV` breaks the installation of dependencies (`pnpm` installs only `devDependencies` in the development mode and only `dependencies` in the production mode, and this is not the scenario this repository needs)
