### PR TITLE
React Automatic Runtime was not really supported before

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@ node_modules
 *.cjs.js
 index.js
 build/*
-!build/min.d.ts
 drafts

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ yarn install jsx-dom
 
 **Note:** Using HyperScript? `h` pragma is also supported.
 
-**New:** If you are using [React Automatic Runtime](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx), simply set `jsxImportSource` to `jsx-dom` and you can omit the import.
+**Note:** If you are using [React Automatic Runtime](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx), simply set `jsxImportSource` to `jsx-dom` or `jsx-dom/min` and you can omit the import.
 
 ```jsx
 import React from "jsx-dom"

--- a/build/min.d.ts
+++ b/build/min.d.ts
@@ -1,1 +1,0 @@
-export * from "./index"

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ export const SVGNamespace: "http://www.w3.org/2000/svg"
 
 export function className(value: ClassNames): string
 
-export { createElement as h, createElement as jsx, createElement as jsxs }
+export { createElement as h, jsx as jsxs }
 
 export function useText(initialValue?: string): readonly [Text, (value: string) => void]
 export function useClassList(initialValue?: ClassNames): ClassList
@@ -280,7 +280,35 @@ export function createElement<T extends Element>(
   ...children: ReactNode[]
 ): T
 
-// @TODO: Add typing for `jsx` function.
+// DOM Elements
+export function jsx<K extends keyof ReactHTML, T extends HTMLElementTagNameMap[K]>(
+  type: K,
+  props?: PropsWithChildren<(HTMLAttributes<T> & AttrWithRef<T>)> | null,
+  key?: string
+): T
+export function jsx<K extends keyof ReactSVG, T extends ReactSVG[K]>(
+  type: K,
+  props?: PropsWithChildren<(SVGAttributes<T> & AttrWithRef<T>)> | null,
+  key?: string
+): SVGElement
+export function jsx<T extends Element>(
+  type: string,
+  props?: PropsWithChildren<(AttrWithRef<T> & DOMAttributes<T>)> | null,
+  key?: string
+): T
+
+// Custom components
+export function jsx<P extends {}, T extends Element>(
+  type: ComponentType<P, T>,
+  props?: PropsWithChildren<(Attributes & P)> | null,
+  key?: string
+): T
+
+export function jsx<T extends Element>(
+  type: string,
+  props?: PropsWithChildren<Attributes> | null,
+  key?: string
+): T
 
 export function Fragment(props: { children?: ReactNode }): any // DocumentFragment
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export {
   createElement,
   createElement as h,
   jsx,
+  jsx as jsxs,
   SVGNamespace,
 } from "./jsx-dom"
 

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -1,0 +1,5 @@
+export {
+  jsx,
+  jsx as jsxs,
+  Fragment,
+} from "./jsx-dom"


### PR DESCRIPTION
### Description

At the moment it's impossible to use React Automatic Runtime out of the box. The [reason is](https://github.com/babel/babel/blob/b97a627964a832aac84f0fe9f7be560dce2b60f1/packages/babel-plugin-transform-react-jsx/src/create-plugin.js#L650-L662):

```js
  function getSource(source, importName) {
    switch (importName) {
      case "Fragment":
        return `${source}/${development ? "jsx-dev-runtime" : "jsx-runtime"}`;
      case "jsxDEV":
        return `${source}/jsx-dev-runtime`;
      case "jsx":
      case "jsxs":
        return `${source}/jsx-runtime`;
      case "createElement":
        return source;
    }
  }
```

Babel doesn't use `source` as... source. It adds a *magic string* `jsx-runtime` to the given library name, and there's no such thing as `jsx-dom/jsx-runtime`

Well, long story short: after this PR, `jsx-dom` and `jsx-dom/min` will become valid `jsxImportSource` values

P.S. - Referencing `jsx-dom` as an external library from `*/jsx-runtime` is intentional. This was made to avoid duplication of functionality in a bundle of a dependent project that uses React Automatic Runtime and sometimes imports something like `Component`, `useText` etc directly from `jsx-dom`