### PR TITLE
Fix automatic runtime related bug in Fragment

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,4 +1,3 @@
 {
-  "extension": ["js", "ts", "tsx"],
-  "require": ["ts-node/register/transpile-only", "test/register.js"]
+  "extension": ["js", "ts", "tsx"]
 }

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
   "module": "index.js",
   "scripts": {
     "build": "./scripts/build.ts build",
-    "prepare": "yarn test && yarn build",
+    "prepare": "pnpm test && pnpm build",
     "postpublish": "rm build/index.d.ts",
     "lint": "eslint src/*",
-    "test": "nyc --reporter=html mocha test/test-*.tsx"
+    "test:classic": "nyc --silent mocha -r test/register-classic.js test/test-*.tsx",
+    "test:automatic": "nyc --silent --no-clean mocha -r test/register-automatic.js test/test-*.tsx",
+    "test": "pnpm test:classic && pnpm test:automatic && nyc report --reporter=html"
   },
   "keywords": [
     "jsx",

--- a/src/jsx-dom.ts
+++ b/src/jsx-dom.ts
@@ -33,7 +33,7 @@ export function className(value: any): string {
     return value.map(className).filter(Boolean).join(" ")
   } else if (isObject(value)) {
     return keys(value)
-      .filter((k) => value[k])
+      .filter(k => value[k])
       .join(" ")
   } else if (isVisibleChild(value)) {
     return "" + value
@@ -105,9 +105,9 @@ export function createFactory(tag: string) {
   return createElement.bind(null, tag)
 }
 
-export function Fragment(attr: { children: JSX.Element[] }) {
+export function Fragment(attr: { children: any }) {
   const fragment = document.createDocumentFragment()
-  appendChildren(attr.children, fragment)
+  appendChild(attr.children, fragment)
   return fragment
 }
 
@@ -201,7 +201,7 @@ function appendChildToNode(child: Node, node: Node) {
 }
 
 function normalizeAttribute(s: string, separator: string) {
-  return s.replace(/[A-Z\d]/g, (match) => separator + match.toLowerCase())
+  return s.replace(/[A-Z\d]/g, match => separator + match.toLowerCase())
 }
 
 function attribute(key: string, value: any, node: Element & HTMLOrSVGElement) {
@@ -289,7 +289,11 @@ function attribute(key: string, value: any, node: Element & HTMLOrSVGElement) {
   } else if (value === true) {
     attr(node, key, "")
   } else if (value !== false && value != null) {
-    if (__FULL_BUILD__ && node instanceof SVGElement && !nonPresentationSVGAttributes.test(key)) {
+    if (
+      __FULL_BUILD__ &&
+      node instanceof SVGElement &&
+      !nonPresentationSVGAttributes.test(key)
+    ) {
       attr(node, normalizeAttribute(key, "-"), value)
     } else {
       attr(node, key, value)

--- a/test/register-automatic.js
+++ b/test/register-automatic.js
@@ -1,0 +1,8 @@
+const path = require("path")
+
+require("ts-node").register({
+  transpileOnly: true,
+  compilerOptions: { jsx: "react-jsx", jsxImportSource: path.resolve(__dirname, "../src") },
+})
+
+require("./register")

--- a/test/register-classic.js
+++ b/test/register-classic.js
@@ -1,0 +1,7 @@
+const path = require("path")
+
+require("ts-node").register({
+  transpileOnly: true,
+})
+
+require("./register")

--- a/test/test-main.tsx
+++ b/test/test-main.tsx
@@ -33,7 +33,7 @@ describe("jsx-dom", () => {
       expect(props.a).to.equal(1)
       expect(props.b).to.equal(2)
       expect(props.c).to.equal(3)
-      expect(cast(props).children).to.be.empty
+      expect(cast(props).children ?? []).to.be.empty
       return <div>{props.a + props.b + props.c}</div>
     }
 
@@ -50,7 +50,7 @@ describe("jsx-dom", () => {
         expect(this.props.a).to.equal(1)
         expect(this.props.b).to.equal(2)
         expect(this.props.c).to.equal(3)
-        expect(this.props.children).to.be.empty
+        expect(this.props.children ?? []).to.be.empty
         return <div>{this.props.a + this.props.b + this.props.c}</div>
       }
     }
@@ -244,7 +244,7 @@ describe("jsx-dom", () => {
       let button = null
       const div = (
         <div>
-          <button ref={(e) => (button = e)} />
+          <button ref={e => (button = e)} />
         </div>
       )
       expect(button).not.to.be.null
@@ -272,7 +272,7 @@ describe("jsx-dom", () => {
       const Button = ({ ref }) => <button ref={ref} />
       const div = (
         <div>
-          <Button ref={(e) => (button = e)} />
+          <Button ref={e => (button = e)} />
         </div>
       )
       expect(button).not.to.be.null
@@ -319,7 +319,7 @@ describe("jsx-dom", () => {
   })
 
   describe("events", () => {
-    it("supports event listeners", (done) => {
+    it("supports event listeners", done => {
       const button = (<button onClick={() => done()} />) as HTMLButtonElement
       button.click()
     })
@@ -327,7 +327,7 @@ describe("jsx-dom", () => {
 
   describe("forwardRef", () => {
     // const FancyButton = React.forwardRef((props, ref) => (
-    const FancyButton = (props) => (
+    const FancyButton = props => (
       <button ref={props.ref} className="FancyButton">
         {props.children}
       </button>
@@ -366,6 +366,18 @@ describe("jsx-dom", () => {
       expect(nodes[0].textContent).to.equal("2")
       expect(nodes[1].nodeName).to.equal("SPAN")
       expect(nodes[1].textContent).to.equal("Bonjour")
+    })
+
+    it("supports fragments with a single child", () => {
+      const frag = (
+        <>
+          <span>Bonjour</span>
+        </>
+      )
+      const nodes = frag.childNodes
+      expect(nodes.length).to.equal(1)
+      expect(nodes[0].nodeName).to.equal("SPAN")
+      expect(nodes[0].textContent).to.equal("Bonjour")
     })
   })
 


### PR DESCRIPTION
When using React automatic runtime, the children prop will _not_ be an array if the element only has a single child. `Fragment` currently only handles array-like children. This leads to a runtime error with following code:
```javascript
const frag = <><span>a</span></>;
```
```
TypeError: children is not iterable
```

This change also makes the tests run with both classic and automatic runtimes.