### PR TITLE
Use hybrid npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,23 @@
   "name": "jsx-dom",
   "version": "7.0.0-beta.4",
   "description": "JSX to document.createElement.",
-  "main": "index.js",
-  "module": "index.js",
+  "main": "cjs/index.js",
+  "module": "esm/index.js",
+  "typings": "types/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "require": "./cjs/index.js",
+      "types": "./types/index.d.ts",
+      "default": "./cjs/index.js"
+    },
+    "./min": {
+      "import": "./esm/min/index.js",
+      "require": "./cjs/min/index.js",
+      "types": "./types/min/index.d.ts",
+      "default": "./cjs/index.js"
+    }
+  },
   "private": true,
   "scripts": {
     "build": "./scripts/build.ts build",
@@ -16,7 +31,6 @@
     "jsx",
     "dom"
   ],
-  "typings": "index.d.ts",
   "author": "proteriax",
   "license": "BSD-3-Clause",
   "dependencies": {


### PR DESCRIPTION
Since the last Node.js version that doesn't support ESM, which is Node.js v10, will reach end-of-life soon, ESM is becoming more and more popular. However, some wild-used frameworks (like Next.js and Jest) don't support ESM very well. We have this kind of CJS/ESM incompatibility issue in our product when using `jsx-dom`. So I forked `jsx-dom` and make it to a hybrid npm package that provides both CJS and ESM files.

If you think it's a good idea to make `jsx-dom` a hybrid npm package, you can merge this PR.

If you think it's better to keep the `jsx-dom` as an ESM-only package, I'm fine with this. And we will switch back from our fork version to the original version once our framework has better ESM support. 

---

See also: https://github.com/remirror/remirror/issues/918
