### PR TITLE
Now useClassList supports SVGElement

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -28,7 +28,7 @@ export function useClassList(initialValue?: ClassNames) {
   let list = div.classList
 
   function ClassList(value: Element) {
-    value.className = list.value
+    value.setAttribute("class", list.value)
     list = value.classList
   }
 

--- a/test/test-hooks.tsx
+++ b/test/test-hooks.tsx
@@ -57,4 +57,32 @@ describe("hooks", () => {
     cls.toggle("container", false)
     expect(cls.contains("container")).to.be.false
   })
+
+  it("SVGElement supports useClassList", () => {
+    const cls = React.useClassList()
+    cls.add("me")
+    const svg = <svg class={cls} />
+    expect(svg.classList.value).to.equal("me")
+    expect(cls.size).to.equal(1)
+
+    cls.add("second")
+    expect(svg.classList.value).to.equal("me second")
+    expect(svg.classList.value).to.equal(cls.value)
+    expect(cls.size).to.equal(2)
+
+    cls.remove("me")
+    expect(svg.classList.value).to.equal("second")
+
+    cls.add("container")
+    expect(cls.contains("container")).to.be.true
+
+    cls.toggle("never")
+    expect(cls.contains("never")).to.be.true
+
+    cls.toggle("never")
+    expect(cls.contains("never")).to.be.false
+
+    cls.toggle("container", false)
+    expect(cls.contains("container")).to.be.false
+  })
 })


### PR DESCRIPTION
`SVGElement.className` is deprecated and read-only. Also its type is `SVGAnimatedString` and not `string`. That's why `useClassList` didn't work before

Fixes #59