### PR TITLE
Support rich data properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,19 @@ function Component() {
 }
 ```
 
+5. Rich data jsx properties are accepted, but populated as properties rather than dom attributes. 
+
+```jsx
+class MyCustomElement extends HTMLElement {
+  constructor() {
+    super();
+  }
+}
+customElements.define('my-custom-element', MyCustomElement);
+const richData = { foo: 'bar' }
+return <my-custom-element richData={richData} />
+```
+
 ### Functional and class components
 
 You can write functional and class components and receive passed `props` in the same way in React. Unlike

--- a/src/jsx-dom.ts
+++ b/src/jsx-dom.ts
@@ -286,6 +286,8 @@ function attribute(key: string, value: any, node: Element & HTMLOrSVGElement) {
         node.addEventListener(key, value)
       }
     }
+  } else if (isObject(value)) {
+    node[key] = value
   } else if (value === true) {
     attr(node, key, "")
   } else if (value !== false && value != null) {

--- a/test/test-main.tsx
+++ b/test/test-main.tsx
@@ -199,6 +199,17 @@ describe("jsx-dom", () => {
   })
 
   describe("attributes", () => {
+    it("supports complex objects attributes as properties", () => {
+      class MyCustomElement extends HTMLElement {
+        constructor() {
+          super();
+        }
+      }
+      customElements.define('my-custom-element', MyCustomElement);
+      const richData = { foo: 'bar' }
+      expect((<my-custom-element richData={richData} />).richData).to.equal(richData)
+    })
+
     it("supports boolean attributes", () => {
       expect((<input disabled={true} />).getAttribute("disabled")).to.equal("")
       expect((<input disabled={false} />).getAttribute("disabled")).to.equal(null)


### PR DESCRIPTION
Rich data properties are currently not supported.
This PR enable a consumer to pass complex objects to a custom element.

Here some best practices around the topic:
https://developers.google.com/web/fundamentals/web-components/best-practices#attributes-properties