### PR TITLE
Support select/textarea value, update value types

### DIFF
--- a/src/jsx-dom.ts
+++ b/src/jsx-dom.ts
@@ -146,6 +146,19 @@ export function jsx(tag: any, { children, ...attr }, key?: string) {
     attributes(attr, node)
     appendChild(children, node)
 
+    // Select `option` elements in `select`
+    if (node instanceof window.HTMLSelectElement && attr.value != null) {
+      if (attr.multiple === true && Array.isArray(attr.value)) {
+        const values = attr.value.map(value => String(value))
+
+        node
+          .querySelectorAll("option")
+          .forEach(option => (option.selected = values.includes(option.value)))
+      } else {
+        node.value = attr.value
+      }
+    }
+
     if (isRef(attr.ref)) {
       attr.ref.current = node
     } else if (isFunction(attr.ref)) {
@@ -274,6 +287,17 @@ function attribute(key: string, value: any, node: Element & HTMLOrSVGElement) {
         node.innerHTML = value["__html"]
       }
       return
+    case "value":
+      if (value == null || node instanceof window.HTMLSelectElement) {
+        // skip nullish values
+        // for `<select>` apply value after appending `<option>` elements
+        return
+      } else if (node instanceof window.HTMLTextAreaElement) {
+        node.value = value
+        return
+      }
+      // use attribute for other elements
+      break
     case "spellCheck":
       cast<HTML.Input>(node).spellcheck = value
       return

--- a/test/test-main.tsx
+++ b/test/test-main.tsx
@@ -338,6 +338,79 @@ describe("jsx-dom", () => {
       expect(cast<HTML.TextArea>(<textarea spellCheck={true} />).spellcheck).to.equal(true)
       expect(cast<HTML.TextArea>(<textarea spellCheck={false} />).spellcheck).to.equal(false)
     })
+
+    it("supports value attribute on textarea", () => {
+      expect(cast<HTML.TextArea>(<textarea value="Test" />).value).to.equal("Test")
+      expect(cast<HTML.TextArea>(<textarea value={undefined} />).value).to.equal("")
+    })
+
+    it("supports value attribute on select", () => {
+      const select = (
+        <select value="B">
+          <option value="A"></option>
+          <option value="B"></option>
+          <option value="C"></option>
+        </select>
+      ) as HTMLSelectElement
+
+      expect(select.querySelector<HTMLOptionElement>("[value=B]").selected).to.equal(true)
+
+      const selectDeep = (
+        <select value={["C"]}>
+          <optgroup label="Group 1">
+            <option value="A"></option>
+          </optgroup>
+          <optgroup label="Group 2">
+            <option value="B" selected></option>
+            <option value="C"></option>
+          </optgroup>
+        </select>
+      ) as HTMLSelectElement
+
+      expect(selectDeep.querySelector<HTMLOptionElement>("[value=C]").selected).to.equal(true)
+    })
+
+    it("supports value attribute on select with multiple", () => {
+      const select = (
+        <select multiple value={["B", "C"]}>
+          <option value="A" selected></option>
+          <option value="B" selected></option>
+          <option value="C"></option>
+        </select>
+      ) as HTMLSelectElement
+
+      expect(select.querySelector<HTMLOptionElement>("[value=A]").selected).to.equal(false)
+      expect(select.querySelector<HTMLOptionElement>("[value=B]").selected).to.equal(true)
+      expect(select.querySelector<HTMLOptionElement>("[value=C]").selected).to.equal(true)
+
+      const selectSingle = (
+        <select multiple value={"C"}>
+          <option value="A"></option>
+          <option value="B" selected></option>
+          <option value="C" selected></option>
+        </select>
+      ) as HTMLSelectElement
+
+      expect(selectSingle.querySelector<HTMLOptionElement>("[value=A]").selected).to.equal(false)
+      expect(selectSingle.querySelector<HTMLOptionElement>("[value=B]").selected).to.equal(false)
+      expect(selectSingle.querySelector<HTMLOptionElement>("[value=C]").selected).to.equal(true)
+
+      const selectDeep = (
+        <select multiple value={["A", "B"]}>
+          <optgroup label="Group 1">
+            <option value="A"></option>
+          </optgroup>
+          <optgroup label="Group 2">
+            <option value="B" selected></option>
+            <option value="C"></option>
+          </optgroup>
+        </select>
+      ) as HTMLSelectElement
+
+      expect(selectDeep.querySelector<HTMLOptionElement>("[value=A]").selected).to.equal(true)
+      expect(selectDeep.querySelector<HTMLOptionElement>("[value=B]").selected).to.equal(true)
+      expect(selectDeep.querySelector<HTMLOptionElement>("[value=C]").selected).to.equal(false)
+    })
   })
 
   describe("styles", () => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -993,7 +993,7 @@ export interface AllHTMLAttributes<T> extends HTMLAttributes<T> {
   target?: string | undefined
   type?: string | undefined
   useMap?: string | undefined
-  value?: string | readonly string[] | number | undefined
+  value?: string | number | undefined
   width?: number | string | undefined
   wmode?: string | undefined
   wrap?: string | undefined
@@ -1059,7 +1059,7 @@ interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
   formTarget?: string | undefined
   name?: string | undefined
   type?: "submit" | "reset" | "button" | undefined
-  value?: string | readonly string[] | number | undefined
+  value?: string | number | undefined
 }
 
 interface CanvasHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -1077,7 +1077,7 @@ interface ColgroupHTMLAttributes<T> extends HTMLAttributes<T> {
 }
 
 interface DataHTMLAttributes<T> extends HTMLAttributes<T> {
-  value?: string | readonly string[] | number | undefined
+  value?: string | number | undefined
 }
 
 interface DetailsHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -1218,7 +1218,7 @@ interface LabelHTMLAttributes<T> extends HTMLAttributes<T> {
 }
 
 interface LiHTMLAttributes<T> extends HTMLAttributes<T> {
-  value?: string | readonly string[] | number | undefined
+  value?: number | undefined
 }
 
 interface LinkHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -1271,7 +1271,7 @@ interface MeterHTMLAttributes<T> extends HTMLAttributes<T> {
   max?: number | string | undefined
   min?: number | string | undefined
   optimum?: number | undefined
-  value?: string | readonly string[] | number | undefined
+  value?: number | undefined
 }
 
 interface QuoteHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -1305,7 +1305,7 @@ interface OptionHTMLAttributes<T> extends HTMLAttributes<T> {
   disabled?: boolean | undefined
   label?: string | undefined
   selected?: boolean | undefined
-  value?: string | readonly string[] | number | undefined
+  value?: string | number | undefined
 }
 
 interface OutputHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -1321,7 +1321,7 @@ interface ParamHTMLAttributes<T> extends HTMLAttributes<T> {
 
 interface ProgressHTMLAttributes<T> extends HTMLAttributes<T> {
   max?: number | string | undefined
-  value?: string | readonly string[] | number | undefined
+  value?: number | undefined
 }
 
 interface ScriptHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -1393,7 +1393,7 @@ interface TextareaHTMLAttributes<T> extends HTMLAttributes<T> {
   readOnly?: boolean | undefined
   required?: boolean | undefined
   rows?: number | undefined
-  value?: string | readonly string[] | number | undefined
+  value?: string | number | undefined
   wrap?: string | undefined
 
   onChange?: ChangeEventHandler<T> | undefined


### PR DESCRIPTION
Fixes #69 `value` on `<textarea>` and `<select>` (even with `multiple`) will now work correctly.

I've changed also types of `value` in elements to better reflect DOM. Let me know If you have any objections to this change.